### PR TITLE
Fix broken anchor in OGC API Processes Core documentation links

### DIFF
--- a/src/specs/ogc-api/rulesets/processes-core.ts
+++ b/src/specs/ogc-api/rulesets/processes-core.ts
@@ -6,7 +6,7 @@ import { truthy } from '@geonovum/standards-checker/spectral/functions';
 
 export const OGC_API_PROCESSES_CORE_URI = 'http://www.opengis.net/spec/ogcapi-processes-1/1.0/conf/core';
 
-export const OGC_API_PROCESSES_CORE_DOC_URI = 'https://docs.ogc.org/DRAFTS/18-062r3.html#/req_core_';
+export const OGC_API_PROCESSES_CORE_DOC_URI = 'https://docs.ogc.org/DRAFTS/18-062r3.html#req_core_';
 
 export const SCHEMAS_URI_PREFIX = 'https://raw.githubusercontent.com/opengeospatial/ogcapi-processes/master/openapi/schemas/';
 


### PR DESCRIPTION
## Summary

Fixes #783.

Documentation links in OGC API Processes errors contained a stray slash after the `#`, which broke the anchor link. For example, the error for `/req/core/process-execute-sync-many-json` linked to:

```
https://docs.ogc.org/DRAFTS/18-062r3.html#/req_core_process-execute-sync-many-json
```

The `#/` does not resolve to the requirement anchor.

## Root cause

In `src/specs/ogc-api/rulesets/processes-core.ts`, the `OGC_API_PROCESSES_CORE_DOC_URI` base constant was `...18-062r3.html#/req_core_` — the only ruleset with a stray slash after the hash. All sibling rulesets (`processes-json`, `processes-job-list`, `processes-ogc-process-description`) correctly use `#req_..._`.

## Fix

Removed the slash so anchors now resolve correctly, e.g. `...18-062r3.html#req_core_process-execute-sync-many-json`.

Verified there are no other `html#/` occurrences in the codebase.