### PR TITLE
Fix false-positive geometry metadata violations on place-less features

### DIFF
--- a/src/specs/json-fg/rulesets/circular-arc.test.ts
+++ b/src/specs/json-fg/rulesets/circular-arc.test.ts
@@ -21,6 +21,17 @@ describe('/req/circular-arcs/metadata', () => {
     expect(violations).toHaveLength(0);
   });
 
+  test('Succeeds when a feature collection has a place-less feature and no circular arc geometry (regression: absent "place" must not trip the rule)', async () => {
+    const { place: _omitted, ...placelessFeature } = featureCollectionDoc.features[0];
+
+    const violations = await spectral.run({
+      ...featureCollectionDoc,
+      features: [placelessFeature, ...featureCollectionDoc.features.slice(1)],
+    });
+
+    expect(violations.filter(v => v.code === '/req/circular-arcs/metadata')).toHaveLength(0);
+  });
+
   test('Fails when a feature place has type "CircularString" and does not include the Circular Arcs conformance class', async () => {
     const violations = await spectral.run({
       ...featureDoc,

--- a/src/specs/json-fg/rulesets/circular-arcs.ts
+++ b/src/specs/json-fg/rulesets/circular-arcs.ts
@@ -30,12 +30,14 @@ const circularArcs: RulesetDefinition = {
             if: {
               anyOf: [
                 {
-                  required: ['type'],
+                  required: ['type', 'place'],
                   properties: {
                     type: {
                       const: 'Feature',
                     },
                     place: {
+                      type: 'object',
+                      required: ['type'],
                       properties: {
                         type: {
                           enum: CIRCULAR_ARC_TYPES,
@@ -52,8 +54,11 @@ const circularArcs: RulesetDefinition = {
                     },
                     features: {
                       contains: {
+                        required: ['place'],
                         properties: {
                           place: {
+                            type: 'object',
+                            required: ['type'],
                             properties: {
                               type: {
                                 enum: CIRCULAR_ARC_TYPES,

--- a/src/specs/json-fg/rulesets/polyhedra.test.ts
+++ b/src/specs/json-fg/rulesets/polyhedra.test.ts
@@ -21,6 +21,17 @@ describe('/req/polyhedra/metadata', () => {
     expect(violations).toHaveLength(0);
   });
 
+  test('Succeeds when a feature collection has a place-less feature and no polyhedron geometry (regression: absent "place" must not trip the rule)', async () => {
+    const { place: _omitted, ...placelessFeature } = featureCollectionDoc.features[0];
+
+    const violations = await spectral.run({
+      ...featureCollectionDoc,
+      features: [placelessFeature, ...featureCollectionDoc.features.slice(1)],
+    });
+
+    expect(violations.filter(v => v.code === '/req/polyhedra/metadata')).toHaveLength(0);
+  });
+
   test('Fails when a feature place has type "Polyhedron" and does not include the Polyhedra conformance class', async () => {
     const violations = await spectral.run({
       ...featureDoc,

--- a/src/specs/json-fg/rulesets/polyhedra.ts
+++ b/src/specs/json-fg/rulesets/polyhedra.ts
@@ -25,12 +25,14 @@ const polyhedra: RulesetDefinition = {
             if: {
               anyOf: [
                 {
-                  required: ['type'],
+                  required: ['type', 'place'],
                   properties: {
                     type: {
                       const: 'Feature',
                     },
                     place: {
+                      type: 'object',
+                      required: ['type'],
                       properties: {
                         type: {
                           enum: POLYHEDRON_TYPES,
@@ -47,8 +49,11 @@ const polyhedra: RulesetDefinition = {
                     },
                     features: {
                       contains: {
+                        required: ['place'],
                         properties: {
                           place: {
+                            type: 'object',
+                            required: ['type'],
                             properties: {
                               type: {
                                 enum: POLYHEDRON_TYPES,

--- a/src/specs/json-fg/rulesets/prisms.test.ts
+++ b/src/specs/json-fg/rulesets/prisms.test.ts
@@ -28,6 +28,17 @@ describe('/req/prisms/metadata', () => {
     expect(violations).toHaveLength(0);
   });
 
+  test('Succeeds when a feature collection has a place-less feature and no prism geometry (regression: absent "place" must not trip the rule)', async () => {
+    const { place: _omitted, ...placelessFeature } = featureCollectionDoc.features[0];
+
+    const violations = await spectral.run({
+      ...featureCollectionDoc,
+      features: [placelessFeature, ...featureCollectionDoc.features.slice(1)],
+    });
+
+    expect(violations.filter(v => v.code === '/req/prisms/metadata')).toHaveLength(0);
+  });
+
   test('Fails when a feature place has type "Prism" and does not include the Prisms conformance class', async () => {
     const violations = await spectral.run({
       ...featureDoc,

--- a/src/specs/json-fg/rulesets/prisms.ts
+++ b/src/specs/json-fg/rulesets/prisms.ts
@@ -26,12 +26,14 @@ const prisms: RulesetDefinition = {
             if: {
               anyOf: [
                 {
-                  required: ['type'],
+                  required: ['type', 'place'],
                   properties: {
                     type: {
                       const: 'Feature',
                     },
                     place: {
+                      type: 'object',
+                      required: ['type'],
                       properties: {
                         type: {
                           enum: PRISM_TYPES,
@@ -48,8 +50,11 @@ const prisms: RulesetDefinition = {
                     },
                     features: {
                       contains: {
+                        required: ['place'],
                         properties: {
                           place: {
+                            type: 'object',
+                            required: ['type'],
                             properties: {
                               type: {
                                 enum: PRISM_TYPES,


### PR DESCRIPTION
## Problem

For [`3D_polyhedron_dom_FG.json`](https://raw.githubusercontent.com/Geonovum/ogc-api-workshops/refs/heads/main/JSON-FG/handson/data/FG_data/3D_polyhedron_dom_FG.json) the checker reports `/req/prisms/metadata`, even though the document contains **no** (Multi)Prism geometries.

## Root cause

The `/req/{prisms,polyhedra,circular-arcs}/metadata` rules decide whether a document contains a geometry of the relevant type by matching `place.type` against an enum. The `if` subschema only used JSON Schema `properties`, which is **vacuously true when the property is absent**.

So in the `FeatureCollection` branch, `features.contains` matched any feature that simply *lacked* a `place` (or had a `place` with no `type`). The workshop document's first feature has no `place` member, so `contains` was satisfied → the rule demanded the conformance-class URI → false positive. The single-`Feature` branch had the same latent gap.

This affects all three geometry-type metadata rules; the same place-less feature would also falsely trip `polyhedra` and `circular-arcs`.

## Fix

Require `place` (typed as `object`) and `place.type` in the matched subschema, so a feature only counts when it actually carries a geometry of the target type. `types-schemas` already used `required` in its `contains` and was unaffected.

## Tests

- Added a regression test to each of the three suites: a `FeatureCollection` with a place-less feature and no target geometry must not raise the metadata violation.
- Full `json-fg` suite passes (107 tests); lint clean.