### PR TITLE
Fix false-positive types-schemas violations on geometry root objects

### DIFF
--- a/src/specs/json-fg/rulesets/types-schemas.test.ts
+++ b/src/specs/json-fg/rulesets/types-schemas.test.ts
@@ -384,3 +384,50 @@ describe('/req/types-schemas/single-feature-schema', () => {
     expect(violations).toHaveLength(0);
   });
 });
+
+describe('standalone geometry root object', () => {
+  // A JSON-FG document may be a bare geometry object (the spec's circular-arcs example).
+  // The "Feature Types and Schemas" requirements only constrain features, so none of these
+  // rules must fire: `/req/types-schemas/metadata` must not treat a missing `features` member
+  // as vacuously matching, and `/req/types-schemas/feature-type` must not run its
+  // Feature/FeatureCollection discriminator against a geometry `type`.
+  test('Produces no violations for a "MultiCurve" geometry root object', async () => {
+    const violations = await spectral.run({
+      conformsTo: ['http://www.opengis.net/spec/json-fg-1/1.0/conf/core', 'http://www.opengis.net/spec/json-fg-1/1.0/conf/circular-arcs'],
+      coordRefSys: 'http://www.opengis.net/def/crs/OGC/0/CRS84',
+      type: 'MultiCurve',
+      geometries: [
+        {
+          type: 'CircularString',
+          coordinates: [
+            [4.5342436, 51.5876522],
+            [4.5342459, 51.5876527],
+            [4.534248, 51.5876533],
+          ],
+        },
+        {
+          type: 'CompoundCurve',
+          geometries: [
+            {
+              type: 'LineString',
+              coordinates: [
+                [4.5343077, 51.5877972],
+                [4.5342909, 51.5878242],
+              ],
+            },
+            {
+              type: 'CircularString',
+              coordinates: [
+                [4.5342863, 51.5878494],
+                [4.5342756, 51.5878582],
+                [4.5342598, 51.5878633],
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(violations).toHaveLength(0);
+  });
+});

--- a/src/specs/json-fg/rulesets/types-schemas.ts
+++ b/src/specs/json-fg/rulesets/types-schemas.ts
@@ -25,6 +25,10 @@ const typesSchemas: RulesetDefinition = {
                 { required: ['featureType'] },
                 { required: ['featureSchema'] },
                 {
+                  // `required: ['features']` is essential: without it `properties` is vacuously
+                  // satisfied when `features` is absent (e.g. a standalone geometry root object),
+                  // which would make this branch — and thus the whole `if` — match every document.
+                  required: ['features'],
                   properties: {
                     features: {
                       contains: {
@@ -55,41 +59,53 @@ const typesSchemas: RulesetDefinition = {
       then: {
         function: remoteSchema,
         functionOptions: {
+          // The "Feature Types and Schemas" requirements only constrain features. Gate the
+          // discriminated schema behind an `if` on the root `type` so a standalone geometry root
+          // object (e.g. type "MultiCurve") is ignored rather than failing the Feature/
+          // FeatureCollection discriminator.
           schema: {
-            type: 'object',
-            discriminator: { propertyName: 'type' },
-            oneOf: [
-              {
-                required: ['type', 'featureType'],
-                properties: {
-                  type: {
-                    const: 'Feature',
-                  },
-                },
+            if: {
+              required: ['type'],
+              properties: {
+                type: { enum: ['Feature', 'FeatureCollection'] },
               },
-              {
-                required: ['type'],
-                properties: {
-                  type: {
-                    const: 'FeatureCollection',
+            },
+            then: {
+              type: 'object',
+              discriminator: { propertyName: 'type' },
+              oneOf: [
+                {
+                  required: ['type', 'featureType'],
+                  properties: {
+                    type: {
+                      const: 'Feature',
+                    },
                   },
                 },
-                oneOf: [
-                  { required: ['featureType'] },
-                  {
-                    properties: {
-                      features: {
-                        type: 'array',
-                        items: {
-                          type: 'object',
-                          required: ['featureType'],
+                {
+                  required: ['type'],
+                  properties: {
+                    type: {
+                      const: 'FeatureCollection',
+                    },
+                  },
+                  oneOf: [
+                    { required: ['featureType'] },
+                    {
+                      properties: {
+                        features: {
+                          type: 'array',
+                          items: {
+                            type: 'object',
+                            required: ['featureType'],
+                          },
                         },
                       },
                     },
-                  },
-                ],
-              },
-            ],
+                  ],
+                },
+              ],
+            },
           },
         },
       },


### PR DESCRIPTION
## Problem

A standalone JSON-FG **geometry** object is a valid JSON-FG root (the `core` ruleset's `/req/core/schema-valid` explicitly lists geometry types among the allowed roots). But the "Feature Types and Schemas" ruleset assumed a `Feature`/`FeatureCollection` root, so feeding it the spec's own circular-arcs example — a bare `"type": "MultiCurve"` root — produced two spurious errors:

```
[/req/types-schemas/metadata] "conformsTo" property must contain at least 1 valid item(s)
[/req/types-schemas/feature-type] Object value of tag "type" must be in oneOf
```

## Root cause

- **`/req/types-schemas/metadata`** — the third `if` branch was `{ properties: { features: { contains: … } } }` with no `required: ['features']`. In JSON Schema, `properties` only constrains members that are *present*, so when `features` is absent the branch is **vacuously true**, making the whole `if` match every document and wrongly demanding the `types-schemas` conformance URI.
- **`/req/types-schemas/feature-type`** — the `discriminator: { propertyName: 'type' }` schema (only `Feature`/`FeatureCollection` branches) ran against every root, so a geometry `type` like `MultiCurve` failed the discriminator mapping.

## Fix

- Add `required: ['features']` to the `metadata` rule's third branch so it can no longer match vacuously.
- Gate the `feature-type` discriminator behind `if: { properties: { type: { enum: ['Feature','FeatureCollection'] } } }, then: { … }`, so geometry roots are ignored while a real `Feature` missing `featureType` still fails.

## Audit

I ran every root-level (`given: '$'`) JSON-FG rule against the example. **No other rule false-positives on a geometry root** — `measures`/`polyhedra`/`prisms`/`circular-arcs` metadata rules all gate on `required` members or a `place`/`FeatureCollection` shape, and the custom root functions guard with `isFeature`/`isFeatureCollection`. `types-schemas` was the only ruleset missing those guards.

> Note (out of scope here): the same "geometry only lives inside a feature" assumption means those other rules *silently skip* standalone geometry roots (a coverage gap / false negative), e.g. a bare `Polyhedron` root that omits its conformsTo URI. Not addressed in this PR.

## Tests

Added a regression test asserting zero violations for the spec's `MultiCurve` geometry root object. Full json-fg suite passes (108 tests), lint clean.