### PR TITLE
Name the required conformance class URI in JSON-FG types-schemas metadata message

### DIFF
--- a/src/specs/json-fg/rulesets/types-schemas.ts
+++ b/src/specs/json-fg/rulesets/types-schemas.ts
@@ -16,6 +16,7 @@ const typesSchemas: RulesetDefinition = {
       given: '$',
       documentationUrl: JSON_FG_TYPES_SCHEMAS_DOC_URI + 'metadata',
       severity: 'error',
+      message: `The "conformsTo" member of a JSON-FG root object that contains a "featureType" or "featureSchema" member (on the root object or any feature) SHALL include the value "${JSON_FG_TYPES_SCHEMAS_URI}".`,
       then: {
         function: schema,
         functionOptions: {


### PR DESCRIPTION
## Problem

Validating a JSON-FG document against `/req/types-schemas/metadata` produced a vague message:

> `[/req/types-schemas/metadata] "conformsTo" property must contain at least 1 valid item(s)`

This is ajv's generic wording for the `contains` keyword, surfaced through Spectral's `schema` function. It tells the user that `conformsTo` failed, but never names **which value is absent** — the requirements-class URI it was looking for.

## Fix

Add a rule-level `message` that states the required URI, so the violation reads:

> `The "conformsTo" member of a JSON-FG root object that contains a "featureType" or "featureSchema" member (on the root object or any feature) SHALL include the value "http://www.opengis.net/spec/json-fg-1/1.0/conf/types-schemas".`

This was already the established convention for the sibling JSON-FG metadata rules — `/req/circular-arcs/metadata`, `/req/measures/metadata`, `/req/polyhedra/metadata`, and `/req/prisms/metadata` each name their URI this way. `/req/types-schemas/metadata` was the lone outlier; this brings it in line.

## Scope

Scoped to JSON-FG, as discussed. No schema/logic change — a rule-level `message` only replaces the rendered text.

## Tests

`src/specs/json-fg/rulesets/types-schemas.test.ts` — all 23 tests pass (they assert on rule code, not message text, so no test changes needed).