### PR TITLE
Pin @asyncapi/specs to 6.11.1 (supply chain attack in 6.11.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "prettier": "@geonovum/standards-checker/prettier",
   "dependencies": {
-    "@geonovum/standards-checker": "^1.1.4",
+    "@geonovum/standards-checker": "^1.1.5",
     "luxon": "^3.7.2",
     "ramda": "^0.32.0",
     "react": "^19.2.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geonovum/ogc-checker",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "packageManager": "pnpm@10.33.0",
   "license": "EUPL-1.2",
   "repository": {
@@ -47,5 +47,13 @@
     "typescript": "^6.0.3",
     "vite": "^8.1.4",
     "vitest": "^4.1.10"
+  },
+  "overrides": {
+    "@asyncapi/specs": "6.11.1"
+  },
+  "pnpm": {
+    "overrides": {
+      "@asyncapi/specs": "6.11.1"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@asyncapi/specs': 6.11.1
+
 importers:
 
   .:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
   .:
     dependencies:
       '@geonovum/standards-checker':
-        specifier: ^1.1.4
-        version: 1.1.4(@babel/runtime@7.29.2)(@codemirror/autocomplete@6.20.3)(@codemirror/language@6.12.4)(@codemirror/search@6.7.0)(@codemirror/state@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.43.6)(codemirror@6.0.2)(esbuild@0.28.1)(eslint@10.6.0)(immer@9.0.21)(react-dom@19.2.7(react@19.2.7))(react-router-dom@7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(synckit@0.11.13)(typescript@6.0.3)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1))(vitest@4.1.10(@types/node@26.1.1)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)))
+        specifier: ^1.1.5
+        version: 1.1.5(@babel/runtime@7.29.2)(@codemirror/autocomplete@6.20.3)(@codemirror/language@6.12.4)(@codemirror/search@6.7.0)(@codemirror/state@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.43.6)(codemirror@6.0.2)(esbuild@0.28.1)(eslint@10.6.0)(immer@9.0.21)(react-dom@19.2.7(react@19.2.7))(react-router-dom@7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(synckit@0.11.13)(typescript@6.0.3)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1))(vitest@4.1.10(@types/node@26.1.1)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)))
       luxon:
         specifier: ^3.7.2
         version: 3.7.2
@@ -408,8 +408,8 @@ packages:
     resolution: {integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@geonovum/standards-checker@1.1.4':
-    resolution: {integrity: sha512-RublKoM3ovOcnaC+7Ihy/opFpoXKru1dw6OFTgFvwS5RPjzkrBJ+m41ow3bemToXyZ2Jy3FqhNd68fB14olQ8w==}
+  '@geonovum/standards-checker@1.1.5':
+    resolution: {integrity: sha512-yaC+z1rTW8G6EPhZiggw4a3OpaOqQ975XzXXhxNsgevF3nu7LIXCyqf9PP2/8Ehx1pPhsV7viR5VJ43xA8K73Q==}
     engines: {node: '>=20.17'}
     hasBin: true
     peerDependencies:
@@ -2408,8 +2408,8 @@ snapshots:
 
   '@babel/generator@8.0.0-rc.3':
     dependencies:
-      '@babel/parser': 8.0.0-rc.3
-      '@babel/types': 8.0.0-rc.3
+      '@babel/parser': 8.0.4
+      '@babel/types': 8.0.4
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
       '@types/jsesc': 2.5.1
@@ -2464,7 +2464,7 @@ snapshots:
 
   '@babel/parser@8.0.0-rc.3':
     dependencies:
-      '@babel/types': 8.0.0-rc.3
+      '@babel/types': 8.0.4
 
   '@babel/parser@8.0.4':
     dependencies:
@@ -2498,7 +2498,7 @@ snapshots:
   '@babel/types@8.0.0-rc.3':
     dependencies:
       '@babel/helper-string-parser': 8.0.0
-      '@babel/helper-validator-identifier': 8.0.0-rc.3
+      '@babel/helper-validator-identifier': 8.0.4
 
   '@babel/types@8.0.4':
     dependencies:
@@ -2717,7 +2717,7 @@ snapshots:
       '@eslint/core': 1.2.1
       levn: 0.4.1
 
-  '@geonovum/standards-checker@1.1.4(@babel/runtime@7.29.2)(@codemirror/autocomplete@6.20.3)(@codemirror/language@6.12.4)(@codemirror/search@6.7.0)(@codemirror/state@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.43.6)(codemirror@6.0.2)(esbuild@0.28.1)(eslint@10.6.0)(immer@9.0.21)(react-dom@19.2.7(react@19.2.7))(react-router-dom@7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(synckit@0.11.13)(typescript@6.0.3)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1))(vitest@4.1.10(@types/node@26.1.1)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)))':
+  '@geonovum/standards-checker@1.1.5(@babel/runtime@7.29.2)(@codemirror/autocomplete@6.20.3)(@codemirror/language@6.12.4)(@codemirror/search@6.7.0)(@codemirror/state@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.43.6)(codemirror@6.0.2)(esbuild@0.28.1)(eslint@10.6.0)(immer@9.0.21)(react-dom@19.2.7(react@19.2.7))(react-router-dom@7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(synckit@0.11.13)(typescript@6.0.3)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1))(vitest@4.1.10(@types/node@26.1.1)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)))':
     dependencies:
       '@codemirror/lang-json': 6.0.2
       '@codemirror/lang-yaml': 6.1.3
@@ -3145,7 +3145,7 @@ snapshots:
     dependencies:
       '@stoplight/json': 3.21.7
       '@stoplight/path': 1.3.2
-      '@stoplight/types': 13.6.0
+      '@stoplight/types': 13.20.0
       lodash: 4.18.1
       node-fetch: 2.7.0
       tslib: 2.8.1


### PR DESCRIPTION
## Why

On 2026-07-14, `@asyncapi/specs@6.11.2` and `6.11.2-alpha.1` were published with malicious
code injected via a compromised release pipeline (asyncapi/spec-json-schemas#656). The
payload executes on import (not via install scripts): it installs a persistent remote
access tool and exfiltrates credentials (npm/GitHub tokens, SSH keys, AWS credentials).

This repo depends on `@asyncapi/specs` transitively: `@stoplight/spectral-rulesets`
declares `^6.8.0` on it. Our committed lockfile already pinned the last clean release
(6.11.1) and CI installs with `--frozen-lockfile`, so no build here was compromised. But
while the malicious version was tagged `latest`, any un-frozen re-resolution (a dependency
bump touching the Spectral subtree, or a fresh resolve without the lockfile) would have
pulled it in.

## What

- Pin `@asyncapi/specs` to exactly `6.11.1`, in both dialects so the pin holds regardless
  of which package manager runs the install:
  - `pnpm.overrides`, read by pnpm (our toolchain and CI)
  - top-level `overrides`, read by npm and Bun; ignored by pnpm, so the two coexist
- Update `@geonovum/standards-checker` to `^1.1.5`, the release that carries the same pin
  (Geonovum/standards-checker#67).
- Bump the patch version to `1.0.8` for release.

The lockfile changes are the recorded `overrides` section plus the re-resolved
`@geonovum/standards-checker` subtree; `@asyncapi/specs` stays at 6.11.1.

## Scope and current status

Overrides apply only at the root of an install, so this protects builds of this repo (and
the artifacts CI builds from it), not consumers who install the published package.
Package managers deliberately ignore overrides declared inside dependencies.

Consumers are protected by the registry cleanup instead: npm has since removed both
malicious versions entirely (6.11.2 and 6.11.2-alpha.1, including the `alpha` dist-tag)
and `latest` points to 6.11.1 again, so nothing malicious is reachable by any range, tag,
or exact version. This pin remains as defense-in-depth against a repeat compromise and
should be removed once AsyncAPI ships a verified-clean release above 6.11.1.

After merge: tag `v1.0.8` to trigger the publish workflow.
