### PR TITLE
Deploy GitHub Pages only for final release tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,9 +48,15 @@ jobs:
           fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      # Deploy the web UI to GitHub Pages only for final releases — a
+      # prerelease tag (any version containing a `-`) publishes to npm under
+      # the `beta` dist-tag but must not overwrite the live site.
       - uses: actions/configure-pages@v6
+        if: ${{ !contains(github.ref_name, '-') }}
       - uses: actions/upload-pages-artifact@v5
+        if: ${{ !contains(github.ref_name, '-') }}
         with:
           path: docs
       - uses: actions/deploy-pages@v5
+        if: ${{ !contains(github.ref_name, '-') }}
         id: deployment


### PR DESCRIPTION
Beta releases currently deploy the web UI to GitHub Pages just like finals, so the live site could run ahead of the last final release. The three Pages steps in `publish.yml` (`configure-pages`, `upload-pages-artifact`, `deploy-pages`) now skip when the tag name contains a `-`, mirroring the existing npm dist-tag rule: prerelease versions go to npm under `beta` only, and only final tags update the live site.

Same change as developer-overheid-nl/don-checker#68. CI-only change — no changeset needed.